### PR TITLE
Fix bugs in Internet Explorer 7 & 8

### DIFF
--- a/src/preloadjs/PreloadJS.js
+++ b/src/preloadjs/PreloadJS.js
@@ -873,5 +873,29 @@
 
 	PreloadJS.lib.BrowserDetect = BrowserDetect;
 
+    // ES5 15.4.4.14 Shim for IE 7 & 8
+    // https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/indexOf
+    if (!Array.prototype.indexOf) {
+        Array.prototype.indexOf = function indexOf(sought /*, fromIndex */ ) {
+            if (this === void 0 || this === null)
+                throw new TypeError();
+            var self = Object(this);
+            var length = self.length >>> 0;
+            if (!length)
+                return -1;
+            var i = 0;
+            if (arguments.length > 1)
+                i = toInteger(arguments[1]);
+            // handle negative indices
+            i = i >= 0 ? i : length - Math.abs(i);
+            for (; i < length; i++) {
+                if (i in self && self[i] === sought) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+    }
+
 }(window));
 

--- a/src/preloadjs/TagLoader.js
+++ b/src/preloadjs/TagLoader.js
@@ -56,7 +56,7 @@
 		this._item = item;
 		this._srcAttr = srcAttr || "src";
 		this.useXHR = (useXHR == true);
-		this.isAudio = (item.tag instanceof HTMLAudioElement);
+		this.isAudio = (window.HTMLAudioElement) ? (item.tag instanceof HTMLAudioElement): false;
 		this.tagCompleteProxy = PreloadJS.proxy(this._handleTagLoad, this);
 	};
 
@@ -194,7 +194,7 @@
 		// Delete handlers.
 		var tag = this.getItem().tag;
 		tag.onload = null;
-		tag.removeEventListener("canplaythrough", this.tagCompleteProxy, false);
+		if(tag.removeEventListener) tag.removeEventListener("canplaythrough", this.tagCompleteProxy, false);
 		tag.onstalled = null;
 		tag.onprogress = null;
 		tag.onerror = null;


### PR DESCRIPTION
For some reason my commit decided to say the whole file was changed, but i really only changed a few lines:

I added this as a shim below line 874 in Preload.JS to fix indexOf errors in IE<9:

```
// ES5 15.4.4.14 Shim for IE 7 & 8
// https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/indexOf
if (!Array.prototype.indexOf) {
    Array.prototype.indexOf = function indexOf(sought /*, fromIndex */ ) {
        if (this === void 0 || this === null)
            throw new TypeError();
        var self = Object(this);
        var length = self.length >>> 0;
        if (!length)
            return -1;
        var i = 0;
        if (arguments.length > 1)
            i = toInteger(arguments[1]);
        // handle negative indices
        i = i >= 0 ? i : length - Math.abs(i);
        for (; i < length; i++) {
            if (i in self && self[i] === sought) {
                return i;
            }
        }
        return -1;
    }
}
```

To fix audio element errors I changed line 59 of TagLoader.js
this.isAudio = (window.HTMLAudioElement) ? (item.tag instanceof HTMLAudioElement): false;

To fix event errors on 197 of TagLoader.js i changed the line to:
if(tag.removeEventListener) tag.removeEventListener("canplaythrough", this.tagCompleteProxy, false);
