### PR TITLE
Fixed bug on cutting of param and segment

### DIFF
--- a/src/preloadjs/PreloadJS.js
+++ b/src/preloadjs/PreloadJS.js
@@ -906,8 +906,7 @@ this.createjs = this.createjs||{};
 
 		var dotIndex = path.lastIndexOf(token);
 		var lastPiece = path.substr(dotIndex+1);
-		var endIndex = lastPiece.lastIndexOf(/[\b|\?|\#|\s]/);
-		return (endIndex == -1) ? lastPiece : lastPiece.substr(0, endIndex);
+		return lastPiece.replace(/(.*?)([\b|\?|\#|\s].*)?$/, '$1');
 	};
 
 	p._disposeItem = function(item) {


### PR DESCRIPTION
This patch fixes cutting URI param and segment from extension.
ex.) '/path/to/image.jpg?param1=a#segment' -> 'jpg' (prior, 'jpg?param1=a#segment')

Solution for #21: Cannot preload files with parameter.
