### PR TITLE
Add AAC to sound extensions

### DIFF
--- a/src/preloadjs/LoadQueue.js
+++ b/src/preloadjs/LoadQueue.js
@@ -1335,6 +1335,8 @@ TODO: WINDOWS ISSUES
 				return createjs.LoadQueue.IMAGE;
 			case "ogg":
 			case "mp3":
+			case "m4a":
+			case "aac":
 			case "wav":
 				return createjs.LoadQueue.SOUND;
 			case "json":


### PR DESCRIPTION
In HTML5 games, MPEG-4 AAC and Ogg Vorbis are preferred audio codecs so AAC support is needed.

Here is an article by the developer of Construct 2.
https://www.scirra.com/blog/64/why-you-shouldnt-use-mp3-in-your-html5-games
