### PR TITLE
IE8 with cross-domain XHR requests gives "Line: 184 Error: 'loaded' is null or not an object"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea/*

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,5 @@
+SetEnvIf Request_URI "/assets/" is_static_asset
+Header set Access-Control-Allow-Origin "*" env=is_static_asset
+Header set Access-Control-Allow-Headers "*" env=is_static_asset
+Header set Access-Control-Allow-Methods "GET" env=is_static_asset
+

--- a/examples/PreloadCORS.html
+++ b/examples/PreloadCORS.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>PreloadJS: Queue Example</title>
+
+	<link rel="stylesheet" type="text/css" href="./assets/demoStyles.css" />
+	<style type="text/css">
+		#template {
+			display:none;
+		}
+
+		#mainProgress {
+			width: auto;
+			height: 20px;
+			float: none;
+			position: relative;
+		}
+		#mainProgress LABEL { position: absolute; }
+
+		.item {
+			height: 170px;
+			width: 238px;
+			border: 1px solid #eee;
+			background-color: #ddd;
+			padding: 2px;
+			float:left;
+			position: relative;
+			text-align: center;
+		}
+		.item .progress {
+			width: 0;
+			height: 20px;
+			background-color: #9c9;
+			bottom: 0;
+		}
+		.complete {}
+		.error {
+			background-color: #FAA;
+		}
+		.complete DIV, .error DIV { display: none; }
+	</style>
+</head>
+<body onload="init()">
+
+	<header id="header" class="PreloadJS">
+	    <h1><span class="text-product">Preload<strong>JS</strong></span> Preload Queue</h1>
+	    <p>Click "load another" to add another image the the overall queue. As images are added, the preload progress reflects
+		    the overall loaded progress. Click "load all" to queue everything at once.
+		    Note that when loading images and sounds locally, you need to ensure that PreloadJS uses tag loading to avoid
+		    cross-origin errors.</p>
+	</header>
+
+	<div id="container" class="content">
+		<input type="button" id="loadAnotherBtn" value="Load Another" disabled="disabled" />
+		<input type="button" id="loadAllBtn" value="Load All" disabled="disabled" />
+		<input type="button" id="reloadBtn" value="Reset" />
+		<div id="mainProgress" class="item">
+			<label>Overall Progress</label><div class="progress"></div>
+		</div>
+		<hr />
+		<!-- New items will get placed here -->
+	</div>
+
+	<!-- Item Template. This is cloned whenever we want a new one. -->
+	<div id="template" class="item">
+		<div class="progress"></div>
+	</div>
+
+    <script type="text/javascript" src="../src/easeljs/events/EventDispatcher.js"></script>
+    <script type="text/javascript" src="../src/preloadjs/AbstractLoader.js"></script>
+    <script type="text/javascript" src="../src/preloadjs/LoadQueue.js"></script>
+    <script type="text/javascript" src="../src/preloadjs/TagLoader.js"></script>
+    <script type="text/javascript" src="../src/preloadjs/XHRLoader.js"></script>
+
+    <!-- We also provide hosted minified versions of all CreateJS libraries.
+      http://code.createjs.com -->
+
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+
+    <script type="text/javascript">
+
+        var map = {};
+        var preload;
+        var loader;
+        var manifest;
+        var w = 238; // Item width
+        var h = 170; // Item height
+
+        function init() {
+            if (window.top != window) {
+                document.getElementById("header").style.display = "none";
+            }
+
+            $("#loadAnotherBtn").click(loadAnother);
+            $("#loadAllBtn").click(loadAll);
+            $("#reloadBtn").click(reload);
+
+            reload();
+        }
+
+        // Reset everything
+        function reload() {
+            // If there is an open preload queue, close it.
+            if (preload != null) { preload.close(); }
+
+            // Reset the UI
+            $("#reloadBtn").css("display", "none");
+            $(".box").remove();
+            $("#mainProgress .progress").width(0);
+
+            $("#loadAnotherBtn").attr("disabled", null);
+            $("#loadAllBtn").attr("disabled", null);
+
+            // Push each item into our manifest
+            manifest = [
+                "assets/image0.jpg",
+                "assets/image1.jpg",
+                "assets/image2.jpg",
+                "assets/image3.jpg",
+                "assets/Autumn.png",
+                "assets/BlueBird.png",
+                "assets/Nepal.jpg",
+                "assets/Texas.jpg"
+            ];
+
+            // Create a preloader. There is no manifest added to it up-front, we will add items on-demand.
+            preload = new createjs.LoadQueue();
+
+            // Use this instead to use tag loading
+            //preload = new createjs.LoadQueue(false);
+
+            preload.addEventListener("fileload", handleFileLoad);
+            preload.addEventListener("progress", handleOverallProgress);
+            preload.addEventListener("fileprogress", handleFileProgress);
+            preload.addEventListener("error", handleFileError);
+            preload.setMaxConnections(5);
+        }
+
+        function stop() {
+            if (preload != null) { preload.close(); }
+        }
+
+        function loadAll() {
+            while (manifest.length > 0) {
+                loadAnother();
+            }
+        }
+
+        function loadAnother() {
+            // Get the next manifest item, and load it
+            var item = manifest.shift();
+            preload.loadFile(item);
+
+            // If we have no more items, disable the UI.
+            if (manifest.length == 0) {
+                $("#loadAnotherBtn").attr("disabled", "disabled");
+                $("#loadAllBtn").attr("disabled", "disabled");
+                $("#reloadBtn").css("display","inline");
+            }
+
+            // Create a new loader display item
+            var div = $("#template").clone();
+            div.attr("id", ""); // Wipe out the ID
+            div.addClass("box")
+            $("#container").append(div);
+            map[item] = div; // Store a reference to each item by its src
+        }
+
+        // File complete handler
+        function handleFileLoad(event) {
+            var div = map[event.item.src];
+            div.addClass("complete");
+
+            // Get a reference to the loaded image (<img/>)
+            var img = event.result;
+
+            // Resize it to fit inside the item
+            var r = img.width/img.height;
+            var ir = w/h
+            if (r > ir) {
+                img.width = w;
+                img.height = w/r;
+            } else {
+                img.height = h;
+                img.width = h;
+            }
+            div.append(img); // Add it to the DOM
+        }
+
+        // File progress handler
+        function handleFileProgress(event) {
+            var div = map[event.item.src]; // Lookup the related item
+            div.children("DIV").width(event.progress*div.width()); // Set the width the progress.
+        }
+
+        // Overall progress handler
+        function handleOverallProgress(event) {
+            $("#mainProgress > .progress").width(preload.progress * $("#mainProgress").width());
+        }
+
+        // An error happened on a file
+        function handleFileError(event) {
+            var div = map[event.item.src];
+            div.addClass("error");
+        }
+
+    </script>
+
+</body>
+</html>

--- a/examples/PreloadCORS.html
+++ b/examples/PreloadCORS.html
@@ -113,14 +113,14 @@
 
             // Push each item into our manifest
             manifest = [
-                "assets/image0.jpg",
-                "assets/image1.jpg",
-                "assets/image2.jpg",
-                "assets/image3.jpg",
-                "assets/Autumn.png",
-                "assets/BlueBird.png",
-                "assets/Nepal.jpg",
-                "assets/Texas.jpg"
+                "http://preloadjs.crossdomain.dev/examples/assets/image0.jpg",
+                "http://preloadjs.crossdomain.dev/examples/assets/image1.jpg",
+                "http://preloadjs.crossdomain.dev/examples/assets/image2.jpg",
+                "http://preloadjs.crossdomain.dev/examples/assets/image3.jpg",
+                "http://preloadjs.crossdomain.dev/examples/assets/Autumn.png",
+                "http://preloadjs.crossdomain.dev/examples/assets/BlueBird.png",
+                "http://preloadjs.crossdomain.dev/examples/assets/Nepal.jpg",
+                "http://preloadjs.crossdomain.dev/examples/assets/Texas.jpg"
             ];
 
             // Create a preloader. There is no manifest added to it up-front, we will add items on-demand.

--- a/src/preloadjs/XHRLoader.js
+++ b/src/preloadjs/XHRLoader.js
@@ -181,7 +181,7 @@ this.createjs = this.createjs || {};
 	 * @private
 	 */
 	p._handleProgress = function (event) {
-		if (event.loaded > 0 && event.total == 0) {
+		if (!event || event.loaded > 0 && event.total == 0) {
 			return; // Sometimes we get no "total", so just ignore the progress event.
 		}
 		this._sendProgress({loaded:event.loaded, total:event.total});


### PR DESCRIPTION
This is a fix for a problem with the "progress" event in IE8 when using XHR and CORS requests.

In my fork I've added a copy of `PreloadQueue.html` called `PreloadCORS.html`, and a `.htaccess` file to enable CORS headers on an Apache httpd server, as a way to reproduce the problem on IE8. To reproduce:
1. Reset your local branch to commit `1ba26b4ec417090cca5bc3cec0954b561890837e` (i.e. to revert my fix)
2. Configure httpd to point to the PreloadJS root directory
3. Add `AllowOverride All` to enable the `.htaccess` file
4. Configure `ServerAlias preloadjs.crossdomain.dev` for your virtual host
5. Add preloadjs.crossdomain.dev to your system's hosts file
6. Load `http://<your-domain>/examples/PreloadCORS.html` in IE8 (note: `<your-domain>` should NOT be `preloadjs.crossdomain.dev`).
7. IE8 should report `Line: 184 Error: 'loaded' is null or not an object`.
8. Pull in the last commit on my fork, and the error should no longer occur in IE8. 
