### PR TITLE
Wrong check on XHRLoader

### DIFF
--- a/src/preloadjs/XHRLoader.js
+++ b/src/preloadjs/XHRLoader.js
@@ -376,7 +376,7 @@ this.createjs = this.createjs || {};
 
 		switch (status) {
 			case 404:   // Not Found
-			case 0:     // Not Loaded
+			//case 0:     // Not Loaded
 				return false;
 		}
 		return true;


### PR DESCRIPTION
Status "0" is a valid status when loading local files.

For example:
- Open local html with Chrome (file:///C:/index.html) (Remember to open as: chrome.exe --allow-file-access-from-files)
- Use XHRLoader

var queue = new createjs.LoadQueue( true );
queue.loadManifest( [ 'somefile.js' ], false );
queue.load();

This is typically used on offline html apps like Apache Cordova, Phonegap, etc.
