### PR TITLE
made version a compatible semver

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "PreloadJS",
-	"version": "v0.4.1",
+	"version": "0.4.1",
 	"homepage": "https://github.com/CreateJS/PreloadJS",
 	"authors": [
 		"gskinner",


### PR DESCRIPTION
semver should not contain a `v` at the beginning. This is probably what's breaking bower support.
