### PR TITLE
Added blob type to preload.

### DIFF
--- a/src/preloadjs/LoadQueue.js
+++ b/src/preloadjs/LoadQueue.js
@@ -394,6 +394,15 @@ TODO: WINDOWS ISSUES
 	 */
 	s.XML = "xml";
 
+    /**
+     * The preload type for blobs. It can only be used with XHR and it will only be used if the developer specifies it.
+     * @property BLOB
+     * @type {String}
+     * @default blob
+     * @static
+     */
+    s.BLOB = "blob";
+
 	/**
 	 * Defines a POST request, use for a method value when loading data.
 	 *
@@ -907,6 +916,23 @@ TODO: WINDOWS ISSUES
 				return false;
 		}
 	};
+
+    /**
+     * Determine if a specific type should be loaded as a blob. Plugins MUST change the item type to blob to ensure they
+     * get one. Blobs are loaded using XHR2.
+     * @method isBlob
+     * @param {String} type The item type.
+     * @return {Boolean} If the specified type is blob.
+     * @private
+     */
+    s.isBlob = function(type) {
+        switch (type) {
+            case createjs.LoadQueue.BLOB:
+                return true;
+            default:
+                return false;
+        }
+    };
 
 	/**
 	 * Register a plugin. Plugins can map to load types (sound, image, etc), or specific extensions (png, mp3, etc).

--- a/src/preloadjs/XHRLoader.js
+++ b/src/preloadjs/XHRLoader.js
@@ -490,8 +490,10 @@ this.createjs = this.createjs || {};
 			}
 		}
 
-		// Binary files are loaded differently.
-		if (createjs.LoadQueue.isBinary(item.type)) {
+		// Blobs and binary files are loaded differently.
+        if (createjs.LoadQueue.isBlob(item.type)) {
+            req.responseType = "blob";
+        } else if (createjs.LoadQueue.isBinary(item.type)) {
 			req.responseType = "arraybuffer";
 		}
 


### PR DESCRIPTION
I needed to dowload images as blobs for a project so I added them to preload. The user MUST specify blob as the download type on the manifest, it's not used by default in any case.
