### PR TITLE
Changes to share installed plugins with sub loaders

### DIFF
--- a/src/preloadjs/LoadQueue.js
+++ b/src/preloadjs/LoadQueue.js
@@ -405,6 +405,15 @@ this.createjs = this.createjs || {};
 		this._crossOrigin = crossOrigin;
 
 		/**
+		 * An array of the plugins registered using {{#crossLink "LoadQueue/installPlugin"}}{{/crossLink}}.
+		 * @property _plugins
+		 * @type {Array}
+		 * @private
+		 * @since 0.6.1
+		 */
+		this._plugins = [];	// TODO this might make a good getter / setter
+
+		/**
 		 * An object hash of callbacks that are fired for each file type before the file is loaded, giving plugins the
 		 * ability to override properties of the load. Please see the {{#crossLink "LoadQueue/installPlugin"}}{{/crossLink}}
 		 * method for more information.
@@ -982,6 +991,7 @@ this.createjs = this.createjs || {};
 		if (plugin == null) { return; }
 
 		if (plugin.getPreloadHandlers != null) {
+			this._plugins.push(plugin);
 			var map = plugin.getPreloadHandlers();
 			map.scope = plugin;
 
@@ -1297,6 +1307,7 @@ this.createjs = this.createjs || {};
 		if (item == null) { return; } // Sometimes plugins or types should be skipped.
 		var loader = this._createLoader(item);
 		if (loader != null) {
+			if (loader.plugins) { loader.plugins = this._plugins; }
 			item._loader = loader;
 			this._loadQueue.push(loader);
 			this._loadQueueBackup.push(loader);

--- a/src/preloadjs/LoadQueue.js
+++ b/src/preloadjs/LoadQueue.js
@@ -411,7 +411,7 @@ this.createjs = this.createjs || {};
 		 * @private
 		 * @since 0.6.1
 		 */
-		this._plugins = [];	// TODO this might make a good getter / setter
+		this._plugins = [];
 
 		/**
 		 * An object hash of callbacks that are fired for each file type before the file is loaded, giving plugins the
@@ -1307,7 +1307,7 @@ this.createjs = this.createjs || {};
 		if (item == null) { return; } // Sometimes plugins or types should be skipped.
 		var loader = this._createLoader(item);
 		if (loader != null) {
-			if (loader.plugins) { loader.plugins = this._plugins; }
+			if ("plugins" in loader) { loader.plugins = this._plugins; }
 			item._loader = loader;
 			this._loadQueue.push(loader);
 			this._loadQueueBackup.push(loader);

--- a/src/preloadjs/loaders/ManifestLoader.js
+++ b/src/preloadjs/loaders/ManifestLoader.js
@@ -78,7 +78,7 @@ this.createjs = this.createjs || {};
 		 * @private
 		 * @since 0.6.1
 		 */
-		this.plugins = [];
+		this.plugins = null;
 
 
 	// Protected Properties

--- a/src/preloadjs/loaders/ManifestLoader.js
+++ b/src/preloadjs/loaders/ManifestLoader.js
@@ -69,7 +69,19 @@ this.createjs = this.createjs || {};
 	function ManifestLoader(loadItem) {
 		this.AbstractLoader_constructor(loadItem, null, createjs.AbstractLoader.MANIFEST);
 
-		// protected properties
+	// Public Properties
+		/**
+		 * An array of the plugins registered using {{#crossLink "LoadQueue/installPlugin"}}{{/crossLink}},
+		 * used to pass plugins to new LoadQueues that may be created.
+		 * @property _plugins
+		 * @type {Array}
+		 * @private
+		 * @since 0.6.1
+		 */
+		this.plugins = [];
+
+
+	// Protected Properties
 		/**
 		 * An internal {{#crossLink "LoadQueue"}}{{/crossLink}} that loads the contents of the manifest.
 		 * @property _manifestQueue
@@ -157,6 +169,9 @@ this.createjs = this.createjs || {};
 			queue.on("progress", this._handleManifestProgress, this);
 			queue.on("complete", this._handleManifestComplete, this, true);
 			queue.on("error", this._handleManifestError, this, true);
+			for(var i = 0, l = this.plugins.length; i < l; i++) {	// conserve order of plugins
+				queue.installPlugin(this.plugins[i]);
+			}
 			queue.loadManifest(json);
 		} else {
 			this._sendComplete();


### PR DESCRIPTION
Specifically, LoadQueue will now store off plugins as they are registered and hand them off to any loader that has a .plugins property. Added .plugin property to Manifest loader and install them on any new LoadQueue.