### PR TITLE
Remove trailing comma for this._availableLoaders

### DIFF
--- a/src/preloadjs/LoadQueue.js
+++ b/src/preloadjs/LoadQueue.js
@@ -387,7 +387,7 @@ this.createjs = this.createjs || {};
 			createjs.SVGLoader,
 			createjs.BinaryLoader,
 			createjs.VideoLoader,
-			createjs.TextLoader,
+			createjs.TextLoader
 		];
 
 		/**


### PR DESCRIPTION
IE8 (and below) will parse trailing commas in array and object literals incorrectly.