### PR TITLE
Added basePath support to SpriteSheetLoader

### DIFF
--- a/src/preloadjs/LoadQueue.js
+++ b/src/preloadjs/LoadQueue.js
@@ -1475,7 +1475,7 @@ this.createjs = this.createjs || {};
 		for (var i = 0; i < this._availableLoaders.length; i++) {
 			var loader = this._availableLoaders[i];
 			if (loader && loader.canLoadItem(item)) {
-				return new loader(item, preferXHR);
+				return new loader(item, preferXHR, this._basePath);
 			}
 		}
 

--- a/src/preloadjs/loaders/SpriteSheetLoader.js
+++ b/src/preloadjs/loaders/SpriteSheetLoader.js
@@ -60,7 +60,7 @@ this.createjs = this.createjs || {};
 	 * @extends AbstractLoader
 	 * @constructor
 	 */
-	function SpriteSheetLoader(loadItem, preferXHR) {
+	function SpriteSheetLoader(loadItem, preferXHR, basePath) {
 		this.AbstractLoader_constructor(loadItem, preferXHR, createjs.AbstractLoader.SPRITESHEET);
 
 		// protected properties
@@ -71,6 +71,7 @@ this.createjs = this.createjs || {};
 		 * @private
 		 */
 		this._manifestQueue = null;
+		this._basePath = basePath;
 	}
 
 	var p = createjs.extend(SpriteSheetLoader, createjs.AbstractLoader);
@@ -142,6 +143,9 @@ this.createjs = this.createjs || {};
 	 */
 	p._loadManifest = function (json) {
 		if (json && json.images) {
+			for(var i = json.images.length - 1; i >= 0; i--) {
+				json.images[i] = this._basePath + json.images[i];
+			}
 			var queue = this._manifestQueue = new createjs.LoadQueue(this._preferXHR, this._item.path, this._item.crossOrigin);
 			queue.on("complete", this._handleManifestComplete, this, true);
 			queue.on("fileload", this._handleManifestFileLoad, this);


### PR DESCRIPTION
I have added basePath support to SpriteSheetLoader,
because the current SpriteSheetLoader doesn't take basePath into account when loading spritesheets using SpriteSheetLoader.