### PR TITLE
Fixed bug where variable 's' was undefined in Methods.js

### DIFF
--- a/src/preloadjs/data/Methods.js
+++ b/src/preloadjs/data/Methods.js
@@ -2,6 +2,8 @@
 this.createjs = this.createjs || {};
 
 (function() {
+	var s = {};
+
 	/**
 	 * Defines a POST request, use for a method value when loading data.
 	 * @property POST


### PR DESCRIPTION
It looks like the declaration for 's' was forgotten when Methods was extracted into it's own file.  I added the declaration for 's' to prevent the browser from throwing an undefined error.