### PR TITLE
Fix errorCallback wrong argument

### DIFF
--- a/src/preloadjs/loaders/ImageLoader.js
+++ b/src/preloadjs/loaders/ImageLoader.js
@@ -160,8 +160,8 @@ this.createjs = this.createjs || {};
                 successCallback(this._tag);
             }, this);
 
-            tag.onerror = createjs.proxy(function() {
-                errorCallback(this._tag);
+            tag.onerror = createjs.proxy(function(event) {
+                errorCallback(event);
             }, this);
 		}
 	};


### PR DESCRIPTION
`Abstract._resultFormatFailed()` require an `event` not an `img` element.
