### PR TITLE
ImageLoader: fix wrong argument passed to isLocal

### DIFF
--- a/src/preloadjs/loaders/ImageLoader.js
+++ b/src/preloadjs/loaders/ImageLoader.js
@@ -94,7 +94,7 @@ this.createjs = this.createjs || {};
 
 		var crossOrigin = this._item.crossOrigin;
 		if (crossOrigin == true) { crossOrigin = "Anonymous"; }
-		if (crossOrigin != null && !createjs.URLUtils.isLocal(this._item.src)) {
+		if (crossOrigin != null && !createjs.URLUtils.isLocal(this._item)) {
 			this._tag.crossOrigin = crossOrigin;
 		}
 


### PR DESCRIPTION
Hi,

"crossOrigin" attribute not applied due to wrong argument passed to isLocal method.
