### PR TITLE
remove event listeners when cleaning a load item

### DIFF
--- a/src/preloadjs/LoadQueue.js
+++ b/src/preloadjs/LoadQueue.js
@@ -1833,6 +1833,7 @@ this.createjs = this.createjs || {};
 	 */
 	p._cleanLoadItem = function(loader) {
 		var item = loader.getItem();
+		loader.removeAllEventListeners();
 		if (item) {
 			delete item._loader;
 		}


### PR DESCRIPTION
 possible fix for issue #210 

definitely resolved an issue in our own production uses when reusing a preloader object