### PR TITLE
Fixe format error callback arg.

### DIFF
--- a/src/preloadjs/loaders/ImageLoader.js
+++ b/src/preloadjs/loaders/ImageLoader.js
@@ -161,7 +161,7 @@ this.createjs = this.createjs || {};
             }, this);
 
             tag.onerror = createjs.proxy(function() {
-                errorCallback(this._tag);
+                errorCallback(new createjs.ErrorEvent('IMAGE_FORMAT'));
             }, this);
 		}
 	};


### PR DESCRIPTION
Given this._tag as errorCallback arg will cause error dispatch incorrectly,
and the load process will not end.