### PR TITLE
Fixed issue with queue events on Angular 2+

### DIFF
--- a/src/preloadjs/loaders/AbstractLoader.js
+++ b/src/preloadjs/loaders/AbstractLoader.js
@@ -508,10 +508,7 @@ this.createjs = this.createjs || {};
 	 * @protected
 	 */
 	p._isCanceled = function () {
-		if (window.createjs == null || this.canceled) {
-			return true;
-		}
-		return false;
+		return this.canceled;
 	};
 
 	/**


### PR DESCRIPTION
A really small fix for the issue #245. I removed the only one reference to the `window.createjs` variable in whole project. Also tested it with Angular 4 and 5 and didn't notice any issues.