### PR TITLE
Added aac to the list of sounds in RequestUtils.js

### DIFF
--- a/src/preloadjs/utils/RequestUtils.js
+++ b/src/preloadjs/utils/RequestUtils.js
@@ -108,6 +108,7 @@
 			case "ogg":
 			case "mp3":
 			case "webm":
+			case "aac":
 				return createjs.Types.SOUND;
 			case "mp4":
 			case "webm":


### PR DESCRIPTION
The problem with the current state of the file is that if you're loading a sound that's in the AAC format(usually used in safari and edge), this isn't handled by the switch statement and thus defaults to text, so the would be Audio object becomes stringified.