### PR TITLE
Change default type for untyped files with .webm extension

### DIFF
--- a/src/preloadjs/utils/RequestUtils.js
+++ b/src/preloadjs/utils/RequestUtils.js
@@ -107,7 +107,6 @@
 				return createjs.Types.IMAGE;
 			case "ogg":
 			case "mp3":
-			case "webm":
 			case "aac":
 				return createjs.Types.SOUND;
 			case "mp4":


### PR DESCRIPTION
I think it makes more sense for `.webm` files (that have not been explicitely typed) to default to type `createjs.Types.VIDEO`.