### PR TITLE
Add "medium" to weights lookup.

### DIFF
--- a/src/preloadjs/loaders/FontLoader.js
+++ b/src/preloadjs/loaders/FontLoader.js
@@ -200,7 +200,7 @@ this.createjs = this.createjs || {};
 	 * @type {Object}
 	 * @static
 	 */
-	FontLoader.FONT_WEIGHT = {thin:100, extralight:200, ultralight:200, light:300, semilight:300, demilight:300, book:"normal", regular:"normal", semibold:600, demibold:600, extrabold:800, ultrabold:800, black:900, heavy:900};
+	FontLoader.FONT_WEIGHT = {thin:100, extralight:200, ultralight:200, light:300, semilight:300, demilight:300, book:"normal", regular:"normal", medium:500, semibold:600, demibold:600, extrabold:800, ultrabold:800, black:900, heavy:900};
 
 	/**
 	 * The frequency in milliseconds to check for loaded fonts.


### PR DESCRIPTION
Add missing "medium" name to collection of font weight values.

Fixes #246.