### PR TITLE
crossOrigin audio and video

### DIFF
--- a/src/preloadjs/loaders/AbstractMediaLoader.js
+++ b/src/preloadjs/loaders/AbstractMediaLoader.js
@@ -70,6 +70,12 @@ this.createjs = this.createjs || {};
 			this._tag = this._createTag(this._item.src);
 		}
 
+		var crossOrigin = this._item.crossOrigin;
+		if (crossOrigin == true) { crossOrigin = "Anonymous"; }
+		if (crossOrigin != null && !createjs.URLUtils.isLocal(this._item)) {
+			this._tag.crossOrigin = crossOrigin;
+		}
+
 		this._tag.preload = "auto";
 		this._tag.load();
 

--- a/src/preloadjs/loaders/AbstractMediaLoader.js
+++ b/src/preloadjs/loaders/AbstractMediaLoader.js
@@ -71,7 +71,7 @@ this.createjs = this.createjs || {};
 		}
 
 		var crossOrigin = this._item.crossOrigin;
-		if (crossOrigin == true) { crossOrigin = "Anonymous"; }
+		if (crossOrigin === true) { crossOrigin = "Anonymous"; }
 		if (crossOrigin != null && !createjs.URLUtils.isLocal(this._item)) {
 			this._tag.crossOrigin = crossOrigin;
 		}

--- a/src/preloadjs/loaders/ImageLoader.js
+++ b/src/preloadjs/loaders/ImageLoader.js
@@ -94,7 +94,7 @@ this.createjs = this.createjs || {};
 		}
 
 		var crossOrigin = this._item.crossOrigin;
-		if (crossOrigin == true) { crossOrigin = "Anonymous"; }
+		if (crossOrigin === true) { crossOrigin = "Anonymous"; }
 		if (crossOrigin != null && !createjs.URLUtils.isLocal(this._item)) {
 			this._tag.crossOrigin = crossOrigin;
 		}


### PR DESCRIPTION
Video and audio (= media) should also use the crossOrigin property, as otherwise they could taint canvases and probably other things.